### PR TITLE
MR: fix: use with instaed of env

### DIFF
--- a/.github/workflows/daily_report.yml
+++ b/.github/workflows/daily_report.yml
@@ -47,9 +47,9 @@ jobs:
           mask_secrets: "EMAIL_PASSWORD,OPENAI_API_KEY"
 
       - name: Build and run Daily Report Action
-        uses: ./
         id: daily_report
-        env:
+        uses: ./
+        with:
           GITHUB_TOKEN: ${{ steps.setup-secrets-gh-token.outputs.secret1 }}
           REPO_NAME: ${{ github.repository }}
           EMAIL_SENDER: ${{ steps.setup-secrets.outputs.secret1 }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,7 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true
     },
-    "commit-message-editor.view.saveAndClose": true
+    "commit-message-editor.view.saveAndClose": true,
+    "githubLocalActions.actCommand": "gh act",
+    "githubLocalActions.dockerDesktopPath": "/mnt/c/Program\\ Files/Rancher\\ Desktop/Rancher\\ Desktop.exe"
 }


### PR DESCRIPTION
# Task

To run the daily report action directly from local code, the parameter must be provided with `with` and not with `env`

# Description

<!--- START AUTOGENERATED NOTES --->
### Changelog ([#15](https://github.com/jfheinrich-eu/github-daily-report/pull/15))

#### 🐛 Bug Fixes
- use with instaed of env

<!--- END AUTOGENERATED NOTES --->


# Demo

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes